### PR TITLE
split showing titles in confirmation from actual delete functionality (n...

### DIFF
--- a/collective/actions/delete/browser.py
+++ b/collective/actions/delete/browser.py
@@ -88,19 +88,17 @@ class FolderDelete(BrowserView):
         self.paths = None
         self.portal = getSite()
         self.utils = self.portal.plone_utils
-        self.initializePaths()
 
-    def initializePaths(self):
-        form = self.request.form
-        if 'paths' in form:
-            paths = form['paths']
-            # strip portal path from paths only when called from
-            # folder_contents but not when called by submitting
-            # to itself (confirmation screen)
-            if 'confirm' in form and form['confirm'] == 'confirmed':
-                self.paths = paths
-            else:
-                self.paths = [self.strip_portal_path(path) for path in paths]
+        if 'paths' in self.request.form:
+            self.paths = self.request.form['paths']
+
+    def action(self):
+        """ return name of the view """
+        return ('@@%s' % self.__name__)
+
+    def paths(self):
+        """ return paths"""
+        return self.paths
 
     def strip_portal_path(self, path):
         portal_path = self.portal.getPhysicalPath()
@@ -110,13 +108,11 @@ class FolderDelete(BrowserView):
                 path.pop(0)
         return '/'.join(path)
 
-    def action(self):
-        """ return name of the view """
-        return ('@@%s' % self.__name__)
-
     def titles(self):
-        """ return paths """
-        return self.paths
+        """ return paths, without portal_id"""
+
+        stripped_paths = [self.strip_portal_path(path) for path in self.paths]
+        return stripped_paths
 
     def __call__(self):
         """ some documentation """

--- a/collective/actions/delete/templates/confirmation.pt
+++ b/collective/actions/delete/templates/confirmation.pt
@@ -11,9 +11,7 @@
   <body>
 
     <div metal:fill-slot="main">
-       <form method="POST"
-            action="#"
-            tal:attributes="action view/action">
+      
       <h1 class="documentFirstHeading"
           i18n:translate="alert_really_delete_contents"
           i18n:domain="collective.actions.delete"
@@ -21,16 +19,20 @@
         Do you really want to delete those contents ?
       </h1>
 
-      <input type="hidden" name="confirm" value="confirmation" />
-
       <ul>
-         <tal:items repeat="object_title view/titles">
+         <tal:titles repeat="object_title view/titles">
           <li tal:content="object_title">The item title (ID)</li>
-          <input type="hidden" name="paths:list" value="plone/page"
-                                 tal:attributes="value object_title" />
-         </tal:items>
+         </tal:titles>
       </ul>
-
+       
+      <form method="POST"
+            action="#"
+            tal:attributes="action view/action">
+        
+        <tal:items repeat="path view/paths">
+          <input type="hidden" name="paths:list" value="plone/page"
+                                 tal:attributes="value path " />
+        </tal:items>
 
         <div class="formControls">
 


### PR DESCRIPTION
...eeds full paths, especially in Plone 4.3.3)
To make collective.actions.delete work together with Products.CMFPlone 4.3.3, this is necessary 
(https://dev.plone.org/ticket/13603), the code is now updated so it will always use full paths to do the actual deletion.
