### PR TITLE
Fix namespace_packages in setup.py for z3c.autoinclude

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 0.1.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix namespace_packages in setup.py to make z3c.autoinclude work.
+  [idgserpro]
 
 
 0.1.5 (2014-03-12)

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(name='collective.actions.delete',
       url='https://svn.plone.org/svn/collective/collective.actions.delete',
       license='GPL',
       packages=find_packages(exclude=['ez_setup']),
-      namespace_packages=['collective'],
+      namespace_packages=['collective', 'collective.actions'],
       include_package_data=True,
       zip_safe=False,
       install_requires=[


### PR DESCRIPTION
Reference: https://romanofskiat.wordpress.com/2012/09/25/z3c-autoinclude-does-not-automatically-include-a-plone-package/